### PR TITLE
SendChannel producer

### DIFF
--- a/cli/src/main/kotlin/io/provenance/kafka/cli/Main.kt
+++ b/cli/src/main/kotlin/io/provenance/kafka/cli/Main.kt
@@ -1,10 +1,9 @@
 package io.provenance.kafka.cli
 
 import ch.qos.logback.classic.Level
-import io.provenance.kafka.coroutine.acking
-import io.provenance.kafka.coroutine.kafkaChannel
 import io.provenance.kafka.coroutine.kafkaConsumerChannel
-import io.provenance.kafka.coroutine.onEachToTopic
+import io.provenance.kafka.coroutine.kafkaProducerChannel
+import java.time.OffsetDateTime
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
@@ -12,21 +11,15 @@ import kotlinx.cli.required
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.channels.ticker
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.buffer
-import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.produceIn
 import kotlinx.coroutines.flow.receiveAsFlow
-import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.selects.select
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.consumer.ConsumerConfig
-import org.apache.kafka.clients.producer.KafkaProducer
-import org.apache.kafka.clients.producer.Producer
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.StringDeserializer
@@ -51,7 +44,7 @@ fun main(args: Array<String>) {
     parser.parse(args)
 
     val commonProps = mapOf<String, Any>(
-        CommonClientConfigs.GROUP_ID_CONFIG to group,
+        CommonClientConfigs.GROUP_ID_CONFIG to group + OffsetDateTime.now().minute,
         CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG to broker,
         ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java,
         ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java,
@@ -62,34 +55,58 @@ fun main(args: Array<String>) {
     logger("org.apache.kafka").level = Level.WARN
 
     val incoming = kafkaConsumerChannel<String, String>(commonProps, setOf(source))
-        .receiveAsFlow()
-        .buffer()
+    val producer = kafkaProducerChannel<String, String>(commonProps)
 
-	runBlocking {
-		launch(Dispatchers.IO) {
-			incoming
-				.acking {
-					logger("main").info("acking record: ${it.key()} // ${it.value()}")
+    runBlocking {
 
-				}.map {
+        //
+        // Using select
+        //
 
-				}
-				.collect()
-		}
+        launch(Dispatchers.IO) {
+            val ticker = ticker(5000)
+            val i = AtomicInteger(100)
 
-		launch(Dispatchers.IO) {
-			val i = AtomicInteger(0)
-			val producer = KafkaProducer<String, String>(commonProps)
-			ticker(5000).receiveAsFlow().map {
-				logger("main").info("ticker")
-				producer.send(ProducerRecord(source, "test", "test-${i.getAndIncrement()}")).get()
-			}.collect()
-		}
-	}
-}
+            while (true) {
+                select<Unit> {
+                    incoming.onReceive {
+                        logger("main").info("pre-commit: ${it.key} // ${it.value} on ${it.topic}-${it.partition}@${it.offset}")
 
-fun <K, V> Flow<ProducerRecord<K, V>>.produceTo(producer: Producer<K, V>): Flow<ProducerRecord<K, V>> {
-	return channelFlow {
+                        val rec = it
+                        producer.onSend(ProducerRecord(dest, it.key, it.value)) {
+                            val ack = rec.ack()
+                            logger("main").info("post-commit: ${ack.key} // ${ack.value} @ ${rec.offset}")
+                        }
+                    }
 
-	}
+                    ticker.onReceive {
+                        logger("main").info("ticker")
+                        producer.send(ProducerRecord(source, dest, "test-${i.getAndIncrement()}"))
+                    }
+                }
+            }
+        }
+
+        //
+        // Using flows
+        //
+
+        launch(Dispatchers.IO) {
+            incoming.receiveAsFlow().buffer().onEach {
+                logger("main").info("pre-commit: ${it.key} // ${it.value} on ${it.topic}-${it.partition}@${it.offset}")
+                producer.send(ProducerRecord(dest, it.key, it.value))
+                val ack = it.ack()
+                logger("main").info("post-commit: ${ack.key} // ${ack.value} @ ${it.offset}")
+            }.collect()
+        }
+
+        launch(Dispatchers.IO) {
+            val ticker = ticker(5000)
+            val i = AtomicInteger(0)
+            ticker.receiveAsFlow().onEach {
+                logger("main").info("ticker")
+                producer.send(ProducerRecord(source, dest, "test-${i.getAndIncrement()}"))
+            }.collect()
+        }
+    }
 }

--- a/cli/src/main/kotlin/io/provenance/kafka/cli/Main.kt
+++ b/cli/src/main/kotlin/io/provenance/kafka/cli/Main.kt
@@ -79,6 +79,7 @@ fun main(args: Array<String>) {
                         }
                     }
 
+                    // Periodically send messages to kafka so we have something to consumer in the other coroutine above.
                     ticker.onReceive {
                         logger("main").info("ticker")
                         producer.send(ProducerRecord(source, dest, "test-${i.getAndIncrement()}"))
@@ -86,6 +87,10 @@ fun main(args: Array<String>) {
                 }
             }
         }
+
+        //
+        //    OR
+        //
 
         //
         // Using flows
@@ -100,6 +105,7 @@ fun main(args: Array<String>) {
             }.collect()
         }
 
+        // Periodically send messages to kafka so we have something to consumer in the other coroutine above.
         launch(Dispatchers.IO) {
             val ticker = ticker(5000)
             val i = AtomicInteger(0)

--- a/kafka-coroutines-core/src/main/kotlin/io/provenance/kafka/coroutine/AckConsumerRecord.kt
+++ b/kafka-coroutines-core/src/main/kotlin/io/provenance/kafka/coroutine/AckConsumerRecord.kt
@@ -1,11 +1,13 @@
 package io.provenance.kafka.coroutine
 
 import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
 
-interface AckedConsumerRecord<K, V> {
-    val record: ConsumerRecord<K, V>
+interface AckedConsumerRecord<K, V> : KafkaRecord<K, V> {
+    val metadata: OffsetAndMetadata
 }
 
 class AckedConsumerRecordImpl<K, V>(
-    override val record: ConsumerRecord<K, V>
-) : AckedConsumerRecord<K, V>
+    record: ConsumerRecord<K, V>,
+    override val metadata: OffsetAndMetadata
+) : AckedConsumerRecord<K, V>, KafkaRecord<K, V> by wrapping(record)

--- a/kafka-coroutines-core/src/main/kotlin/io/provenance/kafka/coroutine/CommitConsumerRecord.kt
+++ b/kafka-coroutines-core/src/main/kotlin/io/provenance/kafka/coroutine/CommitConsumerRecord.kt
@@ -1,6 +1,7 @@
 package io.provenance.kafka.coroutine
 
 import java.time.Duration
+import kotlinx.coroutines.channels.Channel
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 
@@ -8,12 +9,14 @@ interface CommitConsumerRecord {
     val duration: Duration
     val topicPartition: TopicPartition
     val offsetAndMetadata: OffsetAndMetadata
+    val commitAck: Channel<Unit>
 
     fun asCommitable(): Map<TopicPartition, OffsetAndMetadata> = mapOf(topicPartition to offsetAndMetadata)
 }
 
-class CommitConsumerRecordImpl(
+data class CommitConsumerRecordImpl(
     override val duration: Duration,
     override val topicPartition: TopicPartition,
-    override val offsetAndMetadata: OffsetAndMetadata
+    override val offsetAndMetadata: OffsetAndMetadata,
+    override val commitAck: Channel<Unit>,
 ) : CommitConsumerRecord

--- a/kafka-coroutines-core/src/main/kotlin/io/provenance/kafka/coroutine/Extensions.kt
+++ b/kafka-coroutines-core/src/main/kotlin/io/provenance/kafka/coroutine/Extensions.kt
@@ -1,14 +1,14 @@
 package io.provenance.kafka.coroutine
 
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.transform
+import kotlinx.coroutines.flow.map
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
 internal fun <T, L : Iterable<T>> L.ifEmpty(block: () -> L): L = if (count() == 0) block() else this
 
 fun <K, V> Flow<UnAckedConsumerRecord<K, V>>.acking(
-    block: (ConsumerRecord<K, V>) -> Unit = {}
-): Flow<AckedConsumerRecord<K, V>> = transform {
-    block(it.record)
-    emit(it.ack())
+	block: (ConsumerRecord<K, V>) -> Unit = {}
+): Flow<AckedConsumerRecord<K, V>> = map {
+	block(it.record)
+	it.ack()
 }

--- a/kafka-coroutines-core/src/main/kotlin/io/provenance/kafka/coroutine/Extensions.kt
+++ b/kafka-coroutines-core/src/main/kotlin/io/provenance/kafka/coroutine/Extensions.kt
@@ -2,13 +2,12 @@ package io.provenance.kafka.coroutine
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import org.apache.kafka.clients.consumer.ConsumerRecord
 
 internal fun <T, L : Iterable<T>> L.ifEmpty(block: () -> L): L = if (count() == 0) block() else this
 
 fun <K, V> Flow<UnAckedConsumerRecord<K, V>>.acking(
-	block: (ConsumerRecord<K, V>) -> Unit = {}
+    block: (UnAckedConsumerRecord<K, V>) -> Unit = {}
 ): Flow<AckedConsumerRecord<K, V>> = map {
-	block(it.record)
-	it.ack()
+    block(it)
+    it.ack()
 }

--- a/kafka-coroutines-core/src/main/kotlin/io/provenance/kafka/coroutine/KafkaConsumerChannel.kt
+++ b/kafka-coroutines-core/src/main/kotlin/io/provenance/kafka/coroutine/KafkaConsumerChannel.kt
@@ -21,7 +21,7 @@ import kotlin.concurrent.thread
  *
  */
 @OptIn(ExperimentalCoroutinesApi::class, InternalCoroutinesApi::class)
-fun <K, V> kafkaChannel(
+fun <K, V> kafkaConsumerChannel(
     consumerProperties: Map<String, Any>,
     topics: Set<String>,
     name: String = "kafka-channel",
@@ -29,7 +29,7 @@ fun <K, V> kafkaChannel(
     consumer: Consumer<K, V> = KafkaConsumer(consumerProperties),
     init: Consumer<K, V>.() -> Unit = { subscribe(topics) },
 ): ReceiveChannel<UnAckedConsumerRecord<K, V>> {
-    return KafkaChannel(consumerProperties, topics, name, pollInterval, consumer, init).also {
+    return KafkaConsumerChannel(consumerProperties, topics, name, pollInterval, consumer, init).also {
         Runtime.getRuntime().addShutdownHook(
             Thread {
                 it.cancel()
@@ -41,7 +41,7 @@ fun <K, V> kafkaChannel(
 /**
  *
  */
-open class KafkaChannel<K, V>(
+open class KafkaConsumerChannel<K, V>(
     consumerProperties: Map<String, Any>,
     topics: Set<String> = emptySet(),
     name: String = "kafka-channel",

--- a/kafka-coroutines-core/src/main/kotlin/io/provenance/kafka/coroutine/KafkaProducerChannel.kt
+++ b/kafka-coroutines-core/src/main/kotlin/io/provenance/kafka/coroutine/KafkaProducerChannel.kt
@@ -1,0 +1,79 @@
+package io.provenance.kafka.coroutine
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.channels.ChannelResult
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.selects.SelectClause2
+import kotlinx.coroutines.withContext
+import mu.KotlinLogging
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.Producer
+import org.apache.kafka.clients.producer.ProducerRecord
+
+fun <K, V> kafkaProducerChannel(
+	producerProps: Map<String, Any>,
+	producer: Producer<K, V> = KafkaProducer(producerProps)
+): SendChannel<ProducerRecord<K, V>> = KafkaProducerChannel(producer)
+
+@OptIn(ExperimentalTime::class)
+val DEFAULT_SEND_TIMEOUT = 10.seconds
+
+open class KafkaProducerChannel<K, V>(private val producer: Producer<K, V>) : SendChannel<ProducerRecord<K, V>> {
+	private val log = KotlinLogging.logger {}
+
+	private val closed = AtomicBoolean(false)
+
+	@ExperimentalCoroutinesApi
+	override val isClosedForSend: Boolean = closed.get()
+
+	override val onSend: SelectClause2<ProducerRecord<K, V>, SendChannel<ProducerRecord<K, V>>>
+		get() { TODO() }
+
+	override fun close(cause: Throwable?): Boolean {
+		if (closed.get()) {
+			return true
+		}
+
+		return runCatching {
+			producer.close()
+			closed.set(true)
+			true
+		}.getOrDefault(false)
+	}
+
+	@ExperimentalCoroutinesApi
+	override fun invokeOnClose(handler: (cause: Throwable?) -> Unit) {}
+
+	override suspend fun send(element: ProducerRecord<K, V>) {
+		if (closed.get()) {
+			throw RuntimeException("closed")
+		}
+
+		withContext(Dispatchers.IO) {
+			sendOne(element)
+		}
+	}
+
+	private fun sendOne(record: ProducerRecord<K, V>, timeout: Duration = DEFAULT_SEND_TIMEOUT) {
+		val meta = producer.send(record).get(timeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+		log.info("successfully sent ${meta.serializedValueSize()} ${meta.topic()}-${meta.partition()}@${meta.offset()}")
+	}
+
+	@OptIn(InternalCoroutinesApi::class)
+	override fun trySend(element: ProducerRecord<K, V>): ChannelResult<Unit> {
+		return try {
+			sendOne(element)
+			ChannelResult.success(Unit)
+		} catch (e: Throwable) {
+			close(e)
+			ChannelResult.failure()
+		}
+	}
+}

--- a/kafka-coroutines-core/src/main/kotlin/io/provenance/kafka/coroutine/KafkaRecord.kt
+++ b/kafka-coroutines-core/src/main/kotlin/io/provenance/kafka/coroutine/KafkaRecord.kt
@@ -1,0 +1,35 @@
+package io.provenance.kafka.coroutine
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.header.Header
+import org.apache.kafka.common.record.TimestampType
+
+interface KafkaRecord<K, V> {
+    val topic: String
+    val partition: Int
+    val offset: Long
+    val key: K
+    val value: V
+    val headers: List<Header>
+    val timestamp: Long
+    val timestampType: TimestampType
+    val leaderEpoch: Int?
+    val serializedKeySize: Int
+    val serializedValueSize: Int
+}
+
+internal fun <K, V> wrapping(consumerRecord: ConsumerRecord<K, V>): KafkaRecord<K, V> {
+    return object : KafkaRecord<K, V> {
+        override val topic: String = consumerRecord.topic()
+        override val key: K = consumerRecord.key()
+        override val value: V = consumerRecord.value()
+        override val headers: List<Header> = consumerRecord.headers().toList()
+        override val partition: Int = consumerRecord.partition()
+        override val offset: Long = consumerRecord.offset()
+        override val timestamp: Long = consumerRecord.timestamp()
+        override val timestampType: TimestampType = consumerRecord.timestampType()
+        override val leaderEpoch: Int? = consumerRecord.leaderEpoch().orElseGet { null }
+        override val serializedKeySize: Int = consumerRecord.serializedKeySize()
+        override val serializedValueSize: Int = consumerRecord.serializedValueSize()
+    }
+}

--- a/kafka-coroutines-core/src/main/kotlin/io/provenance/kafka/coroutine/KafkaSink.kt
+++ b/kafka-coroutines-core/src/main/kotlin/io/provenance/kafka/coroutine/KafkaSink.kt
@@ -1,21 +1,17 @@
 package io.provenance.kafka.coroutine
 
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
-import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.Producer
+import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.RecordMetadata
-import kotlin.time.Duration
-import java.util.concurrent.Future
-import java.util.concurrent.TimeUnit
-import kotlin.coroutines.CoroutineContext
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.onEach
-import org.apache.kafka.clients.consumer.ConsumerRecord
 
 suspend fun <T> Future<T>.asDeferred(timeout: Duration = Duration.ZERO, coroutineContext: CoroutineContext = Dispatchers.IO): Deferred<T> {
     return withContext(coroutineContext) {
@@ -41,21 +37,3 @@ class KafkaSink<K, V>(
         return kafkaProducer.send(ProducerRecord(topicName, key, block))
     }
 }
-
-private fun <K, V> sendToTopic(producerRecord: ProducerRecord<K, V>, producer: Producer<K, V>, cb: (RecordMetadata) -> Unit): RecordMetadata {
-    return producer.send(producerRecord).get().also(cb)
-}
-
-suspend fun <T, K, V> Flow<T>.collectToTopic(
-    producerProps: Map<String, Any>,
-    producer: Producer<K, V> = KafkaProducer(producerProps),
-    afterSend: (RecordMetadata) -> Unit = {},
-    block: (T) -> ProducerRecord<K, V>
-) = collect { sendToTopic(block(it), producer, afterSend) }
-
-fun <K, V> Flow<UnAckedConsumerRecord<K, V>>.onEachToTopic(
-    producerProps: Map<String, Any>,
-    producer: Producer<K, V> = KafkaProducer(producerProps),
-    afterSend: (RecordMetadata) -> Unit = {},
-    block: (ConsumerRecord<K, V>) -> ProducerRecord<K, V>
-): Flow<UnAckedConsumerRecord<K, V>> = onEach { sendToTopic(block(it.record), producer, afterSend) }

--- a/kafka-coroutines-core/src/main/kotlin/io/provenance/kafka/coroutine/KafkaSource.kt
+++ b/kafka-coroutines-core/src/main/kotlin/io/provenance/kafka/coroutine/KafkaSource.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 
 open class KafkaSource<K, V>(consumerProps: Map<String, Any>, topic: String) {
 
-    private val incoming = kafkaChannel<K, V>(consumerProps, setOf(topic))
+    private val incoming = kafkaConsumerChannel<K, V>(consumerProps, setOf(topic))
 
     fun beginFlow(): Flow<UnAckedConsumerRecordImpl<K, V>> {
         return incoming.receiveAsFlow().map { it as UnAckedConsumerRecordImpl<K, V> }

--- a/kafka-coroutines-core/src/main/kotlin/io/provenance/kafka/coroutine/UnAckedConsumerRecord.kt
+++ b/kafka-coroutines-core/src/main/kotlin/io/provenance/kafka/coroutine/UnAckedConsumerRecord.kt
@@ -1,23 +1,23 @@
 package io.provenance.kafka.coroutine
 
 import java.time.Duration
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 
-interface UnAckedConsumerRecord<K, V> {
-    val record: ConsumerRecord<K, V>
+interface UnAckedConsumerRecord<K, V> : KafkaRecord<K, V> {
     suspend fun ack(): AckedConsumerRecord<K, V>
 
     fun <R> withValue(block: (ConsumerRecord<K, V>) -> Pair<R, Int>): UnAckedConsumerRecord<K, R>
 }
 
 class UnAckedConsumerRecordImpl<K, V>(
-    override val record: ConsumerRecord<K, V>,
+    private val record: ConsumerRecord<K, V>,
     private val channel: SendChannel<CommitConsumerRecord>,
     private val start: Long
-) : UnAckedConsumerRecord<K, V> {
+) : UnAckedConsumerRecord<K, V>, KafkaRecord<K, V> by wrapping(record) {
 
     override fun <R> withValue(block: (ConsumerRecord<K, V>) -> Pair<R, Int>): UnAckedConsumerRecord<K, R> {
         val newRecord = record.withValue { block(record) }
@@ -28,9 +28,12 @@ class UnAckedConsumerRecordImpl<K, V>(
         val tp = TopicPartition(record.topic(), record.partition())
         val commit = OffsetAndMetadata(record.offset() + 1)
         val time = System.currentTimeMillis() - start
-        channel.send(CommitConsumerRecordImpl(Duration.ofMillis(time), tp, commit))
-
-        return AckedConsumerRecordImpl(record)
+        val ack = Channel<Unit>()
+        channel.send(CommitConsumerRecordImpl(Duration.ofMillis(time), tp, commit, ack)).also {
+            ack.receive()
+            ack.close()
+        }
+        return AckedConsumerRecordImpl(record, commit)
     }
 }
 


### PR DESCRIPTION
* Add producer as coroutine SendChannel
* Better composition for kafka records thru unacked and acked.
* Renamed kafkaChannel -> kafkaConsumerChannel, included kafkaProducerChannel
* Implement missing onSend / onReceive channel select functionality.